### PR TITLE
Enable search term args from the CLI

### DIFF
--- a/src/main/scala/discogs/Search.scala
+++ b/src/main/scala/discogs/Search.scala
@@ -4,7 +4,10 @@ import discogs.client.UserTokenDiscogsClient
 
 object Search {
   def main(args: Array[String]): Unit = {
-    val client = UserTokenDiscogsClient(args(0))
-    println(client.search("Madlib"))
+    val token :: queryList = args.toList
+    val client = UserTokenDiscogsClient(token)
+    val queryBuilder = new StringBuilder()
+    val queryString = queryList.addString(queryBuilder , " ").toString
+    println(client.search(queryString))
   }
 }


### PR DESCRIPTION
- First CLI argument is still expected to be the Discogs user token
- Remaining CLI arguments assumed to be search terms
- Search arguments are concatenated with a single space